### PR TITLE
fix: docker-compose for production build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,17 @@ ENVIRONMENT=dev
 USE_SSL=false
 
 # Database connection information
-# When using in production, use the docker DB service name which is "mysql_db"
-# Otherwise, in dev, use "localhost"
-DB_HOST=localhost
-DB_PORT=8011
 DB_USER=root
 DB_PASSWORD=root
 DB_DATABASE=hs_application
+
+# When using in production, use the docker DB service name which is mysql_db
+# Otherwise, in dev, use localhost
+DB_HOST=localhost
+
+# When using in production use the default mysql port, 3306
+# Otherwise, in dev, use 8011
+DB_PORT=8011
 
 # Hacker Suite Auth URL
 # In dev use the values below, otherwise use the docker service name

--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,13 @@ else
 	docker-compose -f $(prod_docker_compose_file) logs -f
 endif
 
-# prints the logs only from the go app
+# prints the logs only from the app
 logs-app:
-	docker-compose logs -f hs_application
+	docker logs hs_application
 
 # prints the logs only from the database
 logs-db:
-	docker-compose logs -f mysql_db
+	docker logs mysql_db
 
 # shuts down the containers
 down:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "2.1"
 services:
   hs_application:
+    container_name: hs_application
     image: hs_application:latest
     depends_on:
       mysql_db:
@@ -11,7 +12,7 @@ services:
     ports:
       - "${PORT}:${PORT}"
     networks:
-      - internal
+      - internal_hackathon
       - hacker_suite
 
   mysql_db:
@@ -31,6 +32,7 @@ services:
       - internal_hackathon
     volumes:
       - db_store:/var/lib/mysql
+      - ./database/:/docker-entrypoint-initdb.d
 
 # The volume for the database is persistent across launches
 volumes:

--- a/src/app.ts
+++ b/src/app.ts
@@ -92,6 +92,9 @@ export class App {
    * @param app The app to set up the middleware for
    */
 	private readonly middlewareSetup = (app: Express): void => {
+		// Request logging
+		app.use(reqLogger);
+
 		app.use((req, res, next) => {
 			if (req.get('X-Forwarded-Proto') !== 'https' && getConfig().useSSL) {
 				res.redirect(`https://${req.headers.host ?? ''}${req.url}`);
@@ -115,9 +118,6 @@ export class App {
    * @param app The app to set up the middleware for
    */
 	private readonly devMiddlewareSetup = (app: Express): void => {
-		// Request logging
-		app.use(reqLogger);
-
 		// Disable browser caching
 		app.use((req: Request, res: Response, next: NextFunction) => {
 			res.setHeader('Surrogate-Control', 'no-store');
@@ -137,7 +137,7 @@ export class App {
 			password: getConfig().db.password,
 			database: getConfig().db.database,
 			entities: [`${__dirname}/models/db/**/*{.js,.ts}`],
-			synchronize: true // Note: Unsafe in production, use migrations instead
+			synchronize: getConfig().environment === Environment.Dev // Note: Unsafe in production, use migrations instead
 		}
 	];
 }


### PR DESCRIPTION
Fixes a couple of issues we ran into when trying to launch the service in production.

- Ensures the DB and node server are on the same internal docker network
- Sets a custom name for the hs_application container
- Use `docker logs` instead of `docker-compose logs` which is a bit easier to use
- Mounts the MySQL DB init file to run on first startup, creating the `hs_application` database