### PR TITLE
fix: applications close date

### DIFF
--- a/src/settings/hackathon.json
+++ b/src/settings/hackathon.json
@@ -3,8 +3,8 @@
   "fullName": "GreatUniHack 2020",
   "rootDomain": "greatunihack.com",
   "hackathonURL": "https://apply.greatunihack.com",
-  "applicationsOpen": "2020-10-31T12:00:00",
-  "applicationsClose": "2020-11-23T20:00:00",
+  "applicationsOpen": "2020-10-31T12:00:00+00:00",
+  "applicationsClose": "2020-11-27T20:00:00+00:00",
   "review": {
     "minimumReviews": 1
   },


### PR DESCRIPTION
Updates the applications close date to be Friday 27th November 8PM UK time. I also added the `+00:00` to the end of the timestamps to make the timezone explicit.